### PR TITLE
Fix https://github.com/PeterStaev/az_notification_hub/issues/3

### DIFF
--- a/android/src/main/kotlin/com/tangrainc/azure_notification_hub/AzRemoteMessageBackgroundWorker.kt
+++ b/android/src/main/kotlin/com/tangrainc/azure_notification_hub/AzRemoteMessageBackgroundWorker.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.Path
 import kotlin.io.path.createTempFile
 import kotlin.io.path.deleteExisting
+import kotlin.io.path.exists
 import kotlin.io.path.pathString
 import kotlin.io.path.readBytes
 import kotlin.io.path.writeBytes
@@ -139,6 +140,11 @@ class AzRemoteMessageBackgroundWorker(private val context: Context, params: Work
             inputData.getString(AzureNotificationHubPlugin.REMOTE_MESSAGE_FILE_KEY)
         if (messageFile != null) {
             val messageFilePath = Path(messageFile)
+            if (!messageFilePath.exists()) {
+                Log.e(TAG, "Remote message file $messageFile does not exist")
+                return Result.failure()
+            }
+
             val messageBytes = messageFilePath.readBytes()
             messageFilePath.deleteExisting()
 

--- a/android/src/main/kotlin/com/tangrainc/azure_notification_hub/AzureNotificationHubPlugin.kt
+++ b/android/src/main/kotlin/com/tangrainc/azure_notification_hub/AzureNotificationHubPlugin.kt
@@ -28,7 +28,7 @@ class AzureNotificationHubPlugin :
         const val SHARED_PREFERENCES_KEY = "fanh_shared_prefs"
         const val CALLBACK_DISPATCHER_HANDLE_KEY = "callback_dispatcher_handle"
         const val CALLBACK_HANDLE_KEY = "callback_handle"
-        const val REMOTE_MESSAGE_BYTES_KEY = "remote_message_bytes"
+        const val REMOTE_MESSAGE_FILE_KEY = "remote_message_file"
         const val DEFAULT_TEMPLATE_NAME = "FANH DEFAULT TEMPLATE"
     }
 


### PR DESCRIPTION
Currently, the `RemoteMessage` is serialized directly as a byte array into the `inputData` of the `AzRemoteMessageBackgroundWorker`. However, the `Data` class has a huge overhead when serializing a byte array (4x the size of the byte array), which puts a somewhat low limit on the size of the push notification.

This PR proposes a change to use a temporary file for storing the data and only storing the temporary file path in the `inputData` given to the `AzRemoteMessageBackgroundWorker`, removing the data size limit.
The file is deleted once consumed by the `AzRemoteMessageBackgroundWorker.doWork()` method.