### PR TITLE
feat: Add setUserId/getUserId APIs 

### DIFF
--- a/android/src/main/kotlin/com/tangrainc/azure_notification_hub/AzureNotificationHubPlugin.kt
+++ b/android/src/main/kotlin/com/tangrainc/azure_notification_hub/AzureNotificationHubPlugin.kt
@@ -125,6 +125,8 @@ class AzureNotificationHubPlugin :
             "AzNotificationHub.getInitialMessage" -> getInitialMessage(result)
             "AzNotificationHub.getInstallationId" -> getInstallationId(result)
             "AzNotificationHub.getPushChannel" -> getPushChannel(result)
+            "AzNotificationHub.setUserId" -> setUserId(call.argument("userId")!!, result)
+            "AzNotificationHub.getUserId" -> getUserId(result)
 
             else -> result.notImplemented()
         }
@@ -206,5 +208,14 @@ class AzureNotificationHubPlugin :
 
     private fun getPushChannel(result: Result) {
         result.success(NotificationHub.getPushChannel())
+    }
+
+    private fun setUserId(userId: String, result: Result) {
+        val success = NotificationHub.setUserId(userId)
+        result.success(success)
+    }
+
+    private fun getUserId(result: Result) {
+        result.success(NotificationHub.getUserId())
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -65,8 +65,10 @@ class _MyAppState extends State<MyApp> {
   late Future<List<String>> _tagsFuture;
   late Future<String> _installationIdFuture;
   late Future<String> _pushChannelFuture;
+  late Future<String> _userIdFuture;
   bool _isSettingTemplateIn = false;
   bool _isRemovingTemplateIn = false;
+  final _userIdController = TextEditingController();
 
   @override
   void initState() {
@@ -83,6 +85,7 @@ class _MyAppState extends State<MyApp> {
     _tagsFuture = AzureNotificationHub.instance.getTags();
     _installationIdFuture = AzureNotificationHub.instance.getInstallationId();
     _pushChannelFuture = AzureNotificationHub.instance.getPushChannel();
+    _userIdFuture = AzureNotificationHub.instance.getUserId();
   }
 
   @override
@@ -90,6 +93,7 @@ class _MyAppState extends State<MyApp> {
     _messageSubscription.cancel();
     _messageOpenedAppSubscription.cancel();
     _tagController.dispose();
+    _userIdController.dispose();
 
     super.dispose();
   }
@@ -213,6 +217,59 @@ class _MyAppState extends State<MyApp> {
                     },
                   );
                 },
+              ),
+              const SizedBox(height: 16),
+              Text(
+                "User ID",
+                style: Theme.of(context).textTheme.headlineLarge,
+              ),
+              FutureBuilder(
+                future: _userIdFuture,
+                builder: (context, snapshot) {
+                  return switch (snapshot) {
+                    (AsyncSnapshot<String> s) when s.hasData => SelectableText(s.data!.isEmpty ? '(not set)' : s.data!),
+                    (AsyncSnapshot<String> s) when s.hasError => Text('${s.error}'),
+                    _ => const Text('?'),
+                  };
+                },
+              ),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      decoration: const InputDecoration(labelText: 'User ID'),
+                      controller: _userIdController,
+                    ),
+                  ),
+                  ElevatedButton(
+                    onPressed: () async {
+                      try {
+                        await AzureNotificationHub.instance
+                            .setUserId(_userIdController.text);
+                        setState(() {
+                          _userIdFuture = AzureNotificationHub.instance.getUserId();
+                          _userIdController.clear();
+                        });
+                      } catch (e) {
+                        print(e);
+                      }
+                    },
+                    child: const Text('Set'),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: () async {
+                      try {
+                        setState(() {
+                          _userIdFuture = AzureNotificationHub.instance.getUserId();
+                        });
+                      } catch (e) {
+                        print(e);
+                      }
+                    },
+                    child: const Text('Get'),
+                  ),
+                ],
               ),
               const SizedBox(height: 16),
               Text("Template",

--- a/ios/Classes/AzureNotificationHubPlugin.swift
+++ b/ios/Classes/AzureNotificationHubPlugin.swift
@@ -38,6 +38,10 @@ public class AzureNotificationHubPlugin: NSObject, FlutterPlugin, MSNotification
             getInstallationId(result: result)
         case "AzNotificationHub.getPushChannel":
             getPushChannel(result: result)
+        case "AzNotificationHub.setUserId":
+            setUserId(userId: (call.arguments as! [String:Any?])["userId"] as! String, result: result)
+        case "AzNotificationHub.getUserId":
+            getUserId(result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -129,6 +133,18 @@ public class AzureNotificationHubPlugin: NSObject, FlutterPlugin, MSNotification
     private func getPushChannel(result: @escaping FlutterResult) {
         let pushChannel = MSNotificationHub.getPushChannel()
         result(pushChannel)
+    }
+    
+    private func setUserId(userId: String, result: @escaping FlutterResult) {
+        // Note: iOS SDK's setUserId() returns void, unlike Android which returns boolean.
+        // Therefore, we always return true to indicate the method was called successfully.
+        MSNotificationHub.setUserId(userId)
+        result(true)
+    }
+    
+    private func getUserId(result: @escaping FlutterResult) {
+        let userId = MSNotificationHub.getUserId()
+        result(userId ?? "")
     }
     
 }

--- a/lib/az_notification_hub.dart
+++ b/lib/az_notification_hub.dart
@@ -72,4 +72,14 @@ class AzureNotificationHub {
   Future<String> getPushChannel() {
     return AzureNotificationHubPlatform.instance.getPushChannel();
   }
+
+  /// Set the user ID for the device.
+  Future<bool> setUserId(String userId) {
+    return AzureNotificationHubPlatform.instance.setUserId(userId);
+  }
+
+  /// Get the user ID for the device.
+  Future<String> getUserId() {
+    return AzureNotificationHubPlatform.instance.getUserId();
+  }
 }

--- a/lib/az_notification_hub_method_channel.dart
+++ b/lib/az_notification_hub_method_channel.dart
@@ -172,4 +172,21 @@ class MethodChannelAzureNotificationHub extends AzureNotificationHubPlatform {
     );
     return result ?? '';
   }
+
+  @override
+  Future<bool> setUserId(String userId) async {
+    final success = await methodChannel.invokeMethod<bool>(
+      'AzNotificationHub.setUserId',
+      {'userId': userId},
+    );
+    return success ?? false;
+  }
+
+  @override
+  Future<String> getUserId() async {
+    final result = await methodChannel.invokeMethod<String>(
+      'AzNotificationHub.getUserId',
+    );
+    return result ?? '';
+  }
 }

--- a/lib/az_notification_hub_platform_interface.dart
+++ b/lib/az_notification_hub_platform_interface.dart
@@ -106,4 +106,14 @@ abstract class AzureNotificationHubPlatform extends PlatformInterface {
   Future<String> getPushChannel() {
     throw UnimplementedError('getPushChannel() has not been implemented.');
   }
+
+  /// Set the user ID for the device.
+  Future<bool> setUserId(String userId) {
+    throw UnimplementedError('setUserId() has not been implemented.');
+  }
+
+  /// Get the user ID for the device.
+  Future<String> getUserId() {
+    throw UnimplementedError('getUserId() has not been implemented.');
+  }
 }


### PR DESCRIPTION
This PR adds `setUserId` and `getUserId` APIs to enable user-based targeting with Azure Notification Hubs.

Fixes #7